### PR TITLE
🔐 Security Fix: Prevent direct access to .env file

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -5,6 +5,12 @@
 
     RewriteEngine On
 
+    # prevent http access to .env
+    <Files ".env">
+        Order Allow,Deny
+        Deny from all
+    </Files>
+
     # Handle Authorization Header
     RewriteCond %{HTTP:Authorization} .
     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]


### PR DESCRIPTION
## Description

.htaccess configuration to block direct access to the configuration (.env) file

## Related Issue

Direct access to the .env file
 - could result in a systemwide security breach
 - leakage of sensitive credentials i.e API keys etc