### PR TITLE
Automatically Load seeder Classes

### DIFF
--- a/app/database/seeds/DatabaseSeeder.php
+++ b/app/database/seeds/DatabaseSeeder.php
@@ -12,8 +12,15 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): array
     {
-        return [
+        /*return [
             UsersSeeder::class,
-        ];
+        ];*/
+
+        // get all classes in the seeder directory
+        $classes = array_diff(scandir(__DIR__), ['.', '..', basename(__FILE__)]);
+
+        return array_map(function ($class) {
+            return __NAMESPACE__ . '\\' . pathinfo($class, PATHINFO_FILENAME);
+        }, $classes);
     }
 }


### PR DESCRIPTION
## Automatically Load seeder Classes

The seeding process initally required users to automatically define the seeder classes in the DB, which there is no problem with it, except when you have to work with a huge application database